### PR TITLE
docs: add figma link

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ ActualIA Android app
 
 Get your own 1 minute daily summary of news that you choose, tailored to your needs. Wake up with the latest in tech, politics, society, or any subject you’d like. You can listen to your customized news feed, read a transcript, and look into the original sources of the headlines that caught your eye.
 
+[See the Figma here](https://www.figma.com/file/vxgSg8jGsV4710Gm9mAyDL/Submissions?type=design&node-id=0-1&mode=design&t=cyFxwt0EOjpTBYSd-0)
+
 ## Architecture Diagram
 ![image](https://github.com/ActualIA/app/assets/18498650/a9d53580-9d8a-428b-b958-e074747dd140)
 


### PR DESCRIPTION
In this PR, we add the forgotten Figma link.