### PR TITLE
82 update news view model and model to store source and audio info

### DIFF
--- a/lib/models/news.dart
+++ b/lib/models/news.dart
@@ -1,18 +1,31 @@
 class News {
   final String title;
   final String date;
+  final int transcriptID;
+  final String? audio;
   final List<Paragraph> paragraphs;
 
   News({
     required this.title,
     required this.date,
+    required this.transcriptID,
+    required this.audio,
     required this.paragraphs,
   });
 }
 
 class Paragraph {
-  final String text;
-  final String source;
+  final String transcript; //Text of the paragraph
+  final String source; //Newspaper or website where the article comes from
+  final String title; //Title of the article
+  final String date; //Date of the article
+  final String content; //Content of the article
 
-  Paragraph({required this.text, required this.source});
+  Paragraph({
+    required this.transcript,
+    required this.source,
+    required this.title,
+    required this.date,
+    required this.content,
+  });
 }

--- a/lib/viewmodels/news.dart
+++ b/lib/viewmodels/news.dart
@@ -1,4 +1,3 @@
-import 'dart:convert';
 import 'dart:developer';
 import 'package:actualia/models/news.dart';
 import 'package:flutter/foundation.dart';
@@ -66,12 +65,19 @@ class NewsViewModel extends ChangeNotifier {
 
       List<dynamic> newsItems = response['transcript']['articles'];
       List<Paragraph> paragraphs = newsItems.map((item) {
-        return Paragraph(text: item['transcript'], source: item['url']);
+        return Paragraph(
+            transcript: item['transcript'],
+            source: item['source']['name'],
+            title: item['title'],
+            date: item['publishedAt'],
+            content: item['content']);
       }).toList();
 
       _news = News(
         title: response['title'],
         date: response['date'],
+        transcriptID: response['id'],
+        audio: response['audio'],
         paragraphs: paragraphs,
       );
       notifyListeners();
@@ -97,7 +103,16 @@ class NewsViewModel extends ChangeNotifier {
     _news = News(
       date: date.toString().substring(0, 10),
       title: title,
-      paragraphs: [Paragraph(text: message, source: 'System')],
+      transcriptID: -1,
+      audio: null,
+      paragraphs: [
+        Paragraph(
+            transcript: message,
+            source: 'System',
+            title: '',
+            date: '',
+            content: '')
+      ],
     );
   }
 }

--- a/lib/widgets/news_text.dart
+++ b/lib/widgets/news_text.dart
@@ -43,6 +43,7 @@ class NewsText extends StatelessWidget {
           Padding(
             //Box containing the title and the date
             //NB : The alignment will change after we add the button to play the audio
+            //Note for audio : Use the transcriptID and audio fields from the news.
             padding: const EdgeInsets.symmetric(horizontal: 80.0),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
@@ -78,10 +79,13 @@ class NewsText extends StatelessWidget {
                   .map((paragraph) => GestureDetector(
                         onTap: () {
                           //TODO: Action for the source button
+                          //Note for source: Use the fields
+                          //"source", "title", "date" and "content"
+                          //from the paragraph.
                           print("Source du paragraphe: ${paragraph.source}");
                         },
                         child: Text(
-                          '${paragraph.text}\n',
+                          '${paragraph.transcript}\n',
                           style: const TextStyle(
                             color: Colors.black,
                             fontSize: 12,

--- a/test/unit/news_view_model.dart
+++ b/test/unit/news_view_model.dart
@@ -85,7 +85,16 @@ class AlreadyExistingNewsVM extends NewsViewModel {
     setNews(News(
         date: DateTime.now().toIso8601String(),
         title: "News",
-        paragraphs: [Paragraph(text: "text", source: "source")]));
+        transcriptID: -1,
+        audio: null,
+        paragraphs: [
+          Paragraph(
+              transcript: "text",
+              source: "source",
+              title: "title",
+              date: "12-04-2024",
+              content: "content")
+        ]));
     return Future.value();
   }
 
@@ -106,7 +115,16 @@ class NonExistingNewsVM extends NewsViewModel {
       setNews(News(
           date: DateTime.now().toIso8601String(),
           title: "News",
-          paragraphs: [Paragraph(text: "text", source: "source")]));
+          transcriptID: -1,
+          audio: null,
+          paragraphs: [
+            Paragraph(
+                transcript: "text",
+                source: "source",
+                title: "title",
+                date: "12-04-2024",
+                content: "content")
+          ]));
     } else {
       setNews(null);
     }

--- a/test/widgets/news_view.dart
+++ b/test/widgets/news_view.dart
@@ -12,12 +12,37 @@ class MockNewsViewModel extends NewsViewModel {
   MockNewsViewModel() : super(FakeSupabaseClient());
 
   @override
-  News? get news => News(title: "Title", date: "1970-01-01", paragraphs: [
-        Paragraph(text: "text1", source: "source1"),
-        Paragraph(text: "text2", source: "source2"),
-        Paragraph(text: "text3", source: "source3"),
-        Paragraph(text: "text4", source: "source4")
-      ]);
+  News? get news => News(
+          title: "Title",
+          date: "1970-01-01",
+          transcriptID: -1,
+          audio: null,
+          paragraphs: [
+            Paragraph(
+                transcript: "text1",
+                source: "source1",
+                title: "title1",
+                date: "1970-01-01",
+                content: "content1"),
+            Paragraph(
+                transcript: "text2",
+                source: "source2",
+                title: "title2",
+                date: "1970-01-01",
+                content: "content2"),
+            Paragraph(
+                transcript: "text3",
+                source: "source3",
+                title: "title3",
+                date: "1970-01-01",
+                content: "content3"),
+            Paragraph(
+                transcript: "text4",
+                source: "source4",
+                title: "title4",
+                date: "1970-01-01",
+                content: "content4")
+          ]);
 
   @override
   Future<void> getNews(DateTime date) {


### PR DESCRIPTION
This PR updates the model and view model of the news to allow storage of the audio file info as well as the source info.
When launching the app, it should work exactly as it did before, except that clicking on a paragraph now prints the name of the newspaper/webiste that made the article and not a URL.