### PR TITLE
fix: fix body sent for generate-transcript

### DIFF
--- a/lib/viewmodels/news.dart
+++ b/lib/viewmodels/news.dart
@@ -169,7 +169,7 @@ class NewsViewModel extends ChangeNotifier {
   /// Invokes a cloud function to generate news transcripts.
   Future<void> invokeTranscriptFunction() async {
     try {
-      await supabase.functions.invoke('generate-transcript');
+      await supabase.functions.invoke('generate-transcript', body: {});
       log("Cloud function 'transcript' invoked successfully.",
           level: Level.INFO.value);
     } catch (e) {

--- a/lib/viewmodels/news.dart
+++ b/lib/viewmodels/news.dart
@@ -85,6 +85,8 @@ class NewsViewModel extends ChangeNotifier {
   }
 
   Future<void> getNewsList() async {
+    print("suzdgfshidufh");
+
     try {
       var response = await fetchNewsList();
 
@@ -95,9 +97,8 @@ class NewsViewModel extends ChangeNotifier {
         hasNews = true;
         _newsList = response.map<News>((news) => parseNews(news)).toList();
 
-        for (var news in _newsList) {
-          getAudioFile(news).whenComplete(() => notifyListeners());
-        }
+        Future.wait(_newsList.map((e) => getAudioFile(e)))
+            .whenComplete(() => notifyListeners());
 
         // If the date of the first news is more than 12 hours ago, call the cloud function
         if (DateTime.now()

--- a/lib/viewmodels/news.dart
+++ b/lib/viewmodels/news.dart
@@ -85,8 +85,6 @@ class NewsViewModel extends ChangeNotifier {
   }
 
   Future<void> getNewsList() async {
-    print("suzdgfshidufh");
-
     try {
       var response = await fetchNewsList();
 

--- a/test/integration/sources.dart
+++ b/test/integration/sources.dart
@@ -183,7 +183,7 @@ class MockHttp extends BaseMockedHttpClient {
                 },
               ]
             },
-            "date": "2024-04-30T16:48:58.691625+00:00",
+            "date": DateTime.now().toIso8601String(),
             "audio": null
           }
         ], 200, request);

--- a/test/unit/news_view_model.dart
+++ b/test/unit/news_view_model.dart
@@ -65,7 +65,7 @@ class FakeFunctionsClient extends Fake implements FunctionsClient {
       Map<String, dynamic>? body,
       HttpMethod method = HttpMethod.post}) {
     expect(functionName, equals('generate-transcript'));
-    expect(body, isNull);
+    expect(body, equals({}));
     expect(method, equals(HttpMethod.post));
 
     return Future.value(FunctionResponse(status: 200));


### PR DESCRIPTION
Fixes the call to `generate-transcript`, since it requires a JSON body.