### PR TITLE
155 feat discover rss providers from url

### DIFF
--- a/lib/models/providers.dart
+++ b/lib/models/providers.dart
@@ -45,6 +45,7 @@ class _TelegramProviderFactory extends _ProviderFactory {
 class _RSSFeedProviderFactory extends _ProviderFactory {
   const _RSSFeedProviderFactory();
 
+  /// Simple paths which may point to a rss feed.
   static const paths = [
     "/feed/",
     "/rss/",
@@ -53,8 +54,14 @@ class _RSSFeedProviderFactory extends _ProviderFactory {
     "/rss.xml",
     "/blog/rss.xml"
   ];
-  static final _rssUrlRegex = new RegExp(r'"([^"]*(feed|rss)[^"]*)"');
 
+  /// Regex matching any XML attribute containing either "rss" or "feed"
+  static final _rssUrlRegex =
+      RegExp(r'"([^"]*(feed|rss)[^"]*)"', caseSensitive: false);
+
+  /// Checks whether a url is a rss document.
+  ///
+  /// To do so, it requests the url, parses it as a XML file and looks for a <rss></rss> tag.
   Future<bool> _isRss(Uri url) async {
     try {
       var document = XmlDocument.parse((await http.get(url)).body);
@@ -64,9 +71,10 @@ class _RSSFeedProviderFactory extends _ProviderFactory {
     }
   }
 
-  List<String> _listRssUrl(String document) {
+  /// List all the urls that may point to a rss feed in a string. Should be used on HTML documents.
+  List<String> _listRssUrl(String input) {
     var r = _rssUrlRegex
-        .allMatches(document)
+        .allMatches(input)
         .map((m) => m.group(1))
         .whereType<String>()
         .toList();

--- a/lib/models/providers.dart
+++ b/lib/models/providers.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:http/http.dart' as http;
 
 import 'package:dartz/dartz.dart';

--- a/lib/models/providers.dart
+++ b/lib/models/providers.dart
@@ -132,7 +132,9 @@ class RSSFeedProviderFactory extends _ProviderFactory {
       if (feeds.isNotEmpty) {
         return Left(NewsProvider(url: feeds.firstOrNull!.$1.toString()));
       } else {
-        return const Right(["Unable to find related rss feed"]);
+        return const Right([
+          "Unable to find related RSS feed. Please provide the complete URL instead."
+        ]);
       }
     } catch (e) {
       return const Right(["Must be a valid URL"]);

--- a/lib/models/providers.dart
+++ b/lib/models/providers.dart
@@ -52,7 +52,8 @@ class _RSSFeedProviderFactory extends _ProviderFactory {
     "/blog/feed/",
     "/blog/rss/",
     "/rss.xml",
-    "/blog/rss.xml"
+    "/blog/rss.xml",
+    "/pageslug?format=rss"
   ];
 
   /// Regex matching any XML attribute containing either "rss" or "feed"

--- a/lib/viewmodels/providers.dart
+++ b/lib/viewmodels/providers.dart
@@ -20,6 +20,8 @@ class ProvidersViewModel extends ChangeNotifier {
   List<EditedProviderData> get editedProviders => _editedProviders;
   late List<EditedProviderData> _editedProviders;
 
+  bool isPushing = false;
+
   ProvidersViewModel(this.supabase) {
     fetchNewsProviders();
   }
@@ -77,6 +79,9 @@ class ProvidersViewModel extends ChangeNotifier {
 
   Future<bool> pushNewsProviders() async {
     try {
+      isPushing = true;
+      notifyListeners();
+
       var providers =
           await Future.wait(editedProviders.map((e) => e.$1.build(e.$2)));
 
@@ -90,7 +95,9 @@ class ProvidersViewModel extends ChangeNotifier {
           );
         }
 
+        isPushing = false;
         notifyListeners();
+
         return false;
       }
 
@@ -99,9 +106,17 @@ class ProvidersViewModel extends ChangeNotifier {
             .map((e) => e.fold((l) => l.url, (r) => throw AssertionError()))
             .toList()
       }).eq("created_by", supabase.auth.currentUser!.id);
+
+      isPushing = false;
+      notifyListeners();
+
       return true;
     } catch (e) {
       log("Could not push news providers: $e", level: Level.WARNING.value);
+
+      isPushing = false;
+      notifyListeners();
+
       return false;
     }
   }

--- a/lib/views/providers_wizard_view.dart
+++ b/lib/views/providers_wizard_view.dart
@@ -39,7 +39,9 @@ class _ProvidersWizardView extends State<ProvidersWizardView> {
         .toList();
 
     Widget body = const LoadingView(text: "Loading your sources");
-    if (items != null) {
+    if (pvm.isPushing) {
+      body = const LoadingView(text: "Updating");
+    } else if (items != null) {
       var items_ = items as List<ProviderWidget>;
 
       body = Column(children: [

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1133,7 +1133,7 @@ packages:
     source: hosted
     version: "1.0.4"
   xml:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: xml
       sha256: b015a8ad1c488f66851d762d3090a21c600e479dc75e68328c52774040cf9226

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -475,7 +475,7 @@ packages:
     source: hosted
     version: "2.1.0"
   http:
-    dependency: "direct dev"
+    dependency: "direct main"
     description:
       name: http
       sha256: "761a297c042deedc1ffbb156d6e2af13886bb305c2a343a4d972504cd67dd938"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -435,26 +435,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.0"
+    version: "10.0.4"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.3"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.1"
   lints:
     dependency: transitive
     description:
@@ -499,10 +499,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.12.0"
   mime:
     dependency: transitive
     description:
@@ -936,26 +936,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: a1f7595805820fcc05e5c52e3a231aedd0b72972cb333e8c738a8b1239448b6f
+      sha256: "7ee446762c2c50b3bd4ea96fe13ffac69919352bd3b4b17bac3f3465edc58073"
       url: "https://pub.dev"
     source: hosted
-    version: "1.24.9"
+    version: "1.25.2"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.7.0"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: a757b14fc47507060a162cc2530d9a4a2f92f5100a952c7443b5cad5ef5b106a
+      sha256: "2bc4b4ecddd75309300d8096f781c0e3280ca1ef85beda558d33fcbedc2eead4"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.9"
+    version: "0.6.0"
   typed_data:
     dependency: transitive
     description:
@@ -1072,10 +1072,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
+      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
       url: "https://pub.dev"
     source: hosted
-    version: "13.0.0"
+    version: "14.2.1"
   watcher:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -56,6 +56,7 @@ dependencies:
   camera: ^0.10.6
   dartz: ^0.10.1
   xml: ^6.5.0
+  http: ^1.2.1
 
 dev_dependencies:
   flutter_test:
@@ -71,7 +72,6 @@ dev_dependencies:
   integration_test:
     sdk: flutter
   messages: ^0.2.0
-  http: ^1.2.1
   gotrue: ^2.6.1
 
 # For information on the generic Dart part of this file, see the

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -52,6 +52,7 @@ dependencies:
   fluttertoast: ^8.2.5
   url_launcher: ^6.2.6
   dartz: ^0.10.1
+  xml: ^6.5.0
 
 dev_dependencies:
   flutter_test:

--- a/test/unit/providers.dart
+++ b/test/unit/providers.dart
@@ -1,6 +1,16 @@
 import 'package:actualia/models/providers.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart';
+
+class RssClient extends Fake implements Client {
+  @override
+  Future<Response> get(Uri url, {Map<String, String>? headers}) async {
+    return Response(
+        "<!DOCTYPE html><html><head><meta charset='utf-8'><meta http-equiv='X-UA-Compatible' content='IE=edge'><title>NY Times</title></head><body><a href=\"https://rss.nytimes.com/services/xml/rss/nyt/HomePage.xml\"></a></body></html>",
+        200);
+  }
+}
 
 void main() {
   test("Correctly parses GNews provider", () {
@@ -41,5 +51,14 @@ void main() {
         (r) => fail("Provider build should have been successful"));
     (await ProviderType.telegram.build(["clic.news"]))
         .fold((l) => fail("Provider build should have failed"), (r) {});
+  });
+
+  test("RSS discovery", () async {
+    (await ProviderType.rss.build(["http://nytimes.com"])).fold(
+        (l) => expect(
+            l.url,
+            equals(
+                "https://rss.nytimes.com/services/xml/rss/nyt/HomePage.xml")),
+        (r) => fail("Provider build should have been successful"));
   });
 }


### PR DESCRIPTION
Add RSS feed discovery on client side by two methods:
1. Appending predefined pathes to the URL provided by the user.
2. Scraping the HTML of the document at the URL, looking for any URL containing "rss" or "feed", then checking if they are actual feeds.

Closes #155 